### PR TITLE
fix Contact force Penalty

### DIFF
--- a/python/IsaacGymEnvs/isaacgymenvs/tasks/dyros_dynamic_walk.py
+++ b/python/IsaacGymEnvs/isaacgymenvs/tasks/dyros_dynamic_walk.py
@@ -897,8 +897,8 @@ def compute_humanoid_walk_reward(
     thres = left_foot_thres | right_foot_thres
     force_thres_penalty = torch.where(thres.squeeze(-1), -0.2*ones[:], zeros[:])
 
-    contact_force_penalty_thres = 0.1*(1-torch.exp(-0.007*(torch.norm(torch.clamp(lfoot_force[:,2].unsqueeze(-1) - 1.4*9.81*total_mass, min=0.0), dim=1) \
-                                                            + torch.norm(torch.clamp(rfoot_force[:,2].unsqueeze(-1) - 1.4*9.81*total_mass, min=0.0), dim=1))))
+    contact_force_penalty_thres = 0.1*torch.exp(-0.007*(torch.norm(torch.clamp(lfoot_force[:,2].unsqueeze(-1) - 1.4*9.81*total_mass, min=0.0), dim=1) \
+                                                            + torch.norm(torch.clamp(rfoot_force[:,2].unsqueeze(-1) - 1.4*9.81*total_mass, min=0.0), dim=1)))
     contact_force_penalty = torch.where(thres.squeeze(-1), contact_force_penalty_thres[:], 0.1*ones[:])
         
     left_foot_thres_diff = torch.abs(lfoot_force[:,2]-lfoot_force_pre[:,2]).unsqueeze(-1) > 0.2*9.81*total_mass/policy_freq_scale


### PR DESCRIPTION
I just corrected contact_force_penalty_thres code in below. (delete "1-" in code.)

However,
How about this formulation with keep using "1-" method?

contact_force_penalty_thres = **rew_weights["ContactForceThresholdPenalty"]** * (1-torch.exp(-0.007*(torch.norm(torch.clamp(lfoot_force[:,2].unsqueeze(-1) - 1.4*9.81*total_mass, min=0.0), dim=1) \
                                                            + torch.norm(torch.clamp(rfoot_force[:,2].unsqueeze(-1) - 1.4*9.81*total_mass, min=0.0), dim=1))))

contact_force_penalty = torch.where(thres.squeeze(-1), contact_force_penalty_thres[:], **zeros[:]**)

For detail, rew_weights["ContactForceThresholdPenalty"] will be negative value.
And then, rewards will be zero without contact force threshold violation.

in my case, rew_weights["ContactForceThresholdPenalty"] = -3.0 to -5.0 really works for me.